### PR TITLE
Add Meister

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A list of awesome companies currently using Ruby as one of their main backend la
 | | [GoScope.AI](https://www.goscope.ai/) | Streamline Your Product Vision. | | |
 | | [Queue](https://usequeue.com/) | Run your agency on one platform, processing payments, handling client requests, and receiving feedback. | | |
 | | [OpenProject](https://www.openproject.org/) | OpenProject is the leading free and open source project management software. | [💻](https://www.openproject.org/careers/) | [2024/09](https://careers.openproject.org/o/senior-ruby-on-rails-backend-engineer-mfdn) |
+| | [Meister](https://www.meistertask.com/pages/about-us) | Centralized, straightforward work management software for teams. | [💻](https://www.meistertask.com/pages/jobs) | |
 | Construction & Real estate | [Mestamaster](http://mestamaster.com/) | Takt Time project management tools for construction industry (building and renovation) | | |
 | Reading Tools | [StoryGraph](https://www.thestorygraph.com/) | Track your reading and choose your next book based on your mood and favourite topics and themes. | | |
 | Rental Property | [AirBnB](https://airbnb.com/) | Homestays and experiences in various countries and regions. | [💻](https://careers.airbnb.com/) | |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A list of awesome companies currently using Ruby as one of their main backend la
 | | [GoScope.AI](https://www.goscope.ai/) | Streamline Your Product Vision. | | |
 | | [Queue](https://usequeue.com/) | Run your agency on one platform, processing payments, handling client requests, and receiving feedback. | | |
 | | [OpenProject](https://www.openproject.org/) | OpenProject is the leading free and open source project management software. | [💻](https://www.openproject.org/careers/) | [2024/09](https://careers.openproject.org/o/senior-ruby-on-rails-backend-engineer-mfdn) |
-| | [Meister](https://www.meistertask.com/pages/about-us) | Centralized, straightforward work management software for teams. | [💻](https://www.meistertask.com/pages/jobs) | |
+| | [Meister](https://www.meistertask.com/pages/about-us) | Centralized, straightforward work management software for teams. | [💻](https://www.meistertask.com/pages/jobs) | [2024/09](https://www.meistertask.com/pages/jobs/engineering-manager) |
 | Construction & Real estate | [Mestamaster](http://mestamaster.com/) | Takt Time project management tools for construction industry (building and renovation) | | |
 | Reading Tools | [StoryGraph](https://www.thestorygraph.com/) | Track your reading and choose your next book based on your mood and favourite topics and themes. | | |
 | Rental Property | [AirBnB](https://airbnb.com/) | Homestays and experiences in various countries and regions. | [💻](https://careers.airbnb.com/) | |


### PR DESCRIPTION
Add Meister, main sponsor of [EuRuKo 2024](https://2024.euruko.org/#sponsors) and other Ruby conferences. There's no current open developer position but linked engineering manager one mentions Ruby in tech stack.